### PR TITLE
Fix/#13 review

### DIFF
--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -12,7 +12,7 @@ date: 2023-02-01
 
 ## Export annotations
 
-eScriptorium allows users to export annotations (segmentation and transcrption), with or without images, to three different [output formats](#selecting-the-output-format).  
+eScriptorium allows users to export annotations (segmentation and transcription), with or without images, to three different [output formats](#selecting-the-output-format).  
 
 The exporting feature is located in the "images" tab (also accessible at `{base_url}/document/{document-id}/images/`), inside an eScriptorium document.  
 
@@ -28,7 +28,6 @@ Select the relevant document-parts by ticking their checkboxes, then click on th
 In the first drop-down menu, you can select which transcription version is to be exported.  
 
 !!! Note
-
     * Manual transcriptions are registered as the __manual__ version.
     * Imported transcriptions, when batch imported with a zip file, are registered as the __Zip import__ version. <!-- todo: add link to import -->
     * Transcriptions predicted with a model are named with the model. <!-- todo: add link to predict transcription -->

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -10,9 +10,9 @@ date: 2023-02-01
 
 ## Exporting models
 
-## Exporting annotations
+## Export annotations
 
-eScriptorium allows users to export annotations, with or without images, to three different [output formats](#selecting-the-output-format).  
+eScriptorium allows users to export annotations (segmentation and transcrption), with or without images, to three different [output formats](#selecting-the-output-format).  
 
 The exporting feature is located in the "images" tab (also accessible at `{base_url}/document/{document-id}/images/`), inside an eScriptorium document.  
 
@@ -23,19 +23,25 @@ Select the relevant document-parts by ticking their checkboxes, then click on th
 
 ![image: Demonstration of selecting document-parts and then clicking on the 'Export' button](img/export/escriptorium_export_select_partdocuments.gif)
 
-### Selecting the version of the transcription to export
+### Select the transcription version
 
 In the first drop-down menu, you can select which transcription version is to be exported.  
 
 !!! Note
 
-    * Manual annotations are registered as the __manual__ version.
-    * Imported annotations, when batch imported with a zip file, are registered as the __Zip import__ version. <!-- todo: add link to import -->
-    * Annotations predicted with a transcription model are named with the model's name. <!-- todo: add link to predict transcription -->
+    * Manual transcriptions are registered as the __manual__ version.
+    * Imported transcriptions, when batch imported with a zip file, are registered as the __Zip import__ version. <!-- todo: add link to import -->
+    * Transcriptions predicted with a model are named with the model. <!-- todo: add link to predict transcription -->
 
 ![Image: Illustration of the drop-down menu for selecting the version of the transcription](img/export/escriptorium_export_transcription_version.gif)
 
-### Selecting the output format
+!!! Note  
+    When a document-part does not contain any segmentation, an XML file will still be created.  
+
+!!! Note  
+    When a document part does not contain any transcription in the selected transcription version, an XML file will still be created, containing only segmentation information.  
+
+### Select the output format
 
 In the second drop-down menu, you can select between three output formats:
 
@@ -45,7 +51,7 @@ In the second drop-down menu, you can select between three output formats:
 
 ![Image: Illustration of the drop-down menu for selecting the output format](img/export/escriptorium_export_format.gif)
 
-### Including (or not) images linked to the annotations
+### Including or exclude images
 
 You can include the images corresponding to the selected document-parts by ticking the "Include images" checkbox.
 
@@ -53,7 +59,7 @@ As mentioned in the export pop-up box, and depending on the images' sizes, inclu
 
 ![Image: Ticking the checkbox for including images in the export](img/export/escriptorium_export_include_images.gif)
 
-### Selecting the region types to export
+### Include or exclude certain region types or lines
 
 You can include or exclude lines or whole regions and their associated lines with the last parameters. <!-- todo: add link to the subsection about segment version -->
 
@@ -62,14 +68,14 @@ To do so, tick the checkboxes associated to the region types you want to export 
 ![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif)
 
 !!! Note
-    By default, there are __six region types__ available to export : Illustration, Commentary, Main, Title, (Undefined region type), (Orphan lines). (Undefined region type) are regions without a name. (Orphan lines) are lines not linked to any region. Make sure to always tick the checkbox for (Orphan lines) to avoid loosing any not-linked annotation.
+    By default, there are __six region types__ available to export : Illustration, Commentary, Main, Title, (Undefined region type), (Orphan lines). (Undefined region type) are regions without a name. (Orphan lines) are lines not linked to any region. Make sure to always tick the checkbox for (Orphan lines) to avoid losing isolated lines.
 
-You can export a region type even though no annotations are linked to it. It will be mentioned in the resulting exported file, but no annotations will be linked to it.  
+You can export a region type even though it does not contain any transcription. In ALTO and PAGE files, the resulting regions will simply be an empty element.  
 
 !!! Note
-    Region types' name will only appear when exporting in ALTO and PAGE. When exporting as plain text, only the annotations will be exported.
+    Region types' name will only appear when exporting in ALTO and PAGE. In a plain text export, only the text contained in the transcription is kept.
 
-### Downloading the export
+### Download the export
 
 Once all options are set, click on the "Export" button at the bottom of the pop-up. 
 
@@ -84,6 +90,6 @@ When exporting plain text, clicking on "Download" will redirect you to a new URL
 !!! Tip
     If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file).  
 
-### Finding previous exports
+### Find previous exports
 
 Each export is provided a unique permanent link. You can save it, for example to automatically re-download it later without having to set the whole export again but it is also possible to find the links to all your previous exports in the Profile page, under the "Files" tab.<!-- todo: add link to "review and edit your profile" which should logically be : [Profile page, under the "Files" tab](walkthrough_users.md#review-and-edit-your-profile)-->

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -67,12 +67,12 @@ To do so, tick the checkboxes associated to the region types you want to export 
 
 The list of region types corresponds to the region types activated in the "Ontology" tab <!-- todo: add link to that once it's available -->. Two additional options allow you to include or ignore untyped-regions <!-- todo: add link to segmentation, which would hopefully explain that --> or orphan lines (lines that are not linked <!-- todo: add link to linking segments to regions -->to any region).
 
-You can export a region type even though it does not contain any transcription. In ALTO and PAGE files, the resulting regions will simply be an empty element.  
+You can export a region type even though it does not contain any transcription. In ALTO and PAGE files, the resulting regions will simply be empty elements.  
 
 !!! Note
     Regions' type will only appear in ALTO and PAGE. In a plain text export, only the text contained in the transcription is kept.
 
-![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif "Selecting and unselecting region types for the export.")  
+![image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif "Selecting and unselecting region types for the export.")  
 
 ### Download the export
 
@@ -84,7 +84,7 @@ When exporting ALTO and PAGE, the exported file is saved as a zip file containg 
 
 When exporting plain text, clicking on "Download" will redirect you to a new URL, displaying the plain text. All the transcriptions are concatenated as a single text file.
 
-![Image: Illustration of the export](img/export/escriptorium_export_download.png "Stating the export task and downloading the result.")
+![image: Illustration of the export](img/export/escriptorium_export_download.png "Stating the export task and downloading the result.")
 
 !!! Tip
     If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file of course).  

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -21,7 +21,7 @@ Select the relevant document-parts by ticking their checkboxes, then click on th
 !!! Tip
     You can select multiple documents at once by pressing the ++shift++ key.
 
-![image: Demonstration of selecting document-parts and then clicking on the 'Export' button](img/export/escriptorium_export_select_partdocuments.gif)
+![image: Demonstration of selecting document-parts and then clicking on the 'Export' button](img/export/escriptorium_export_select_partdocuments.gif "Selecting document-parts and starting the export.")
 
 ### Select the transcription version
 
@@ -33,7 +33,7 @@ In the first drop-down menu, you can select which transcription version is to be
     * Imported transcriptions, when batch imported with a zip file, are registered as the __Zip import__ version. <!-- todo: add link to import -->
     * Transcriptions predicted with a model are named with the model. <!-- todo: add link to predict transcription -->
 
-![Image: Illustration of the drop-down menu for selecting the version of the transcription](img/export/escriptorium_export_transcription_version.gif)
+![image: Illustration of the drop-down menu for selecting the version of the transcription](img/export/escriptorium_export_transcription_version.gif "Choosing a transcription version")
 
 !!! Note  
     When a document-part does not contain any segmentation, an XML file will still be created.  
@@ -49,7 +49,7 @@ In the second drop-down menu, you can select between three output formats:
 * PAGE for [PAGE XML](http://www.primaresearch.org/publications/ICPR2010_Pletschacher_PAGE)
 * ALTO for [XML ALTO](https://www.loc.gov/standards/alto/) (Analyzed Layout and Text Object)
 
-![Image: Illustration of the drop-down menu for selecting the output format](img/export/escriptorium_export_format.gif)
+![image: Illustration of the drop-down menu for selecting the output format](img/export/escriptorium_export_format.gif "Choosing the output format.")
 
 ### Including or exclude images
 
@@ -57,7 +57,7 @@ You can include the images corresponding to the selected document-parts by ticki
 
 As mentioned in the export pop-up box, and depending on the images' sizes, including image in the export can significantly increase the time to produce and download the export.
 
-![Image: Ticking the checkbox for including images in the export](img/export/escriptorium_export_include_images.gif)
+![image: Ticking the checkbox for including images in the export](img/export/escriptorium_export_include_images.gif "Checking the box to include images in the export.")
 
 ### Include or exclude certain region types or lines
 
@@ -72,7 +72,7 @@ You can export a region type even though it does not contain any transcription. 
 !!! Note
     Regions' type will only appear in ALTO and PAGE. In a plain text export, only the text contained in the transcription is kept.
 
-![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif)  
+![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif "Selecting and unselecting region types for the export.")  
 
 ### Download the export
 
@@ -84,11 +84,11 @@ When exporting ALTO and PAGE, the exported file is saved as a zip file containg 
 
 When exporting plain text, clicking on "Download" will redirect you to a new URL, displaying the plain text. All the transcriptions are concatenated as a single text file.
 
-![Image: Illustration of the export](img/export/escriptorium_export_download.png)
+![Image: Illustration of the export](img/export/escriptorium_export_download.png "Stating the export task and downloading the result.")
 
 !!! Tip
     If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file).  
 
 ### Find previous exports
 
-Each export is provided a unique permanent link. You can save it, for example to automatically re-download it later without having to set the whole export again but it is also possible to find the links to all your previous exports in the Profile page, under the "Files" tab.<!-- todo: add link to "review and edit your profile" which should logically be : [Profile page, under the "Files" tab](walkthrough_users.md#review-and-edit-your-profile)-->
+Each export is provided a unique permanent link. You can save it, for example to automatically re-download it later without having to set the whole export again but it is also possible to find the links to all your previous exports in the Profile page, under the "Files" tab.<!-- todo: add link to "review and edit your profile" which should logically be : [Profile page, under the "Files" tab](walkthrough_users.md#review-and-edit-your-profile)-->  

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -55,7 +55,7 @@ In the second drop-down menu, you can select between three output formats:
 
 You can include the images corresponding to the selected document-parts by ticking the "Include images" checkbox.
 
-As mentioned in the export pop-up box, and depending on the images' sizes, including image in the export can significantly increase the time to produce and download the export.
+As mentioned in the export pop-up box, and depending on the images' size, including images in the export can significantly increase the time to produce and download the export.
 
 ![image: Ticking the checkbox for including images in the export](img/export/escriptorium_export_include_images.gif "Checking the box to include images in the export.")
 

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -12,70 +12,78 @@ date: 2023-02-01
 
 ## Exporting annotations
 
-eScriptorium allows users to export annotations done manually or automatically with a transcription model. 
+eScriptorium allows users to export annotations, with or without images, to three different [output formats](#selecting-the-output-format).  
 
-The exporting feature is located in the "images" tab `{base_url}/document/{document-id}/images/`, inside an eScriptorium document. 
+The exporting feature is located in the "images" tab (also accessible at `{base_url}/document/{document-id}/images/`), inside an eScriptorium document.  
 
-Select the relevant part-documents by ticking their checkboxes, then click on the blue "Export" button, right next to the "Import" button. A pop-up box will then appear.
+Select the relevant document-parts by ticking their checkboxes, then click on the "Export" button, next to the "Import" button. A pop-up box then appears. It allows to set four parameters for the export.
 
 !!! Tip
-    You can select multiple documents at once by pressing the _shift_ button on your keyboard.
-    
-![Image: Demonstration of selecting part-documents and then clicking on the 'Export' button](img/export/escriptorium_export_select_partdocuments.gif)
+    You can select multiple documents at once by pressing the ++shift++ key.
 
-There are four options when exporting part-documents.
+![image: Demonstration of selecting document-parts and then clicking on the 'Export' button](img/export/escriptorium_export_select_partdocuments.gif)
 
 ### Selecting the version of the transcription to export
 
-You can select the version of the transcription to export in the first drop-down menu. 
+In the first drop-down menu, you can select which transcription version is to be exported.  
 
 !!! Note
+
     * Manual annotations are registered as the __manual__ version.
-    * Imported annotations, when batch imported with a zip file, are registered as the __Zip import__ version.
-    * Annotations done with a transcription model are named with the model's name.
-    
+    * Imported annotations, when batch imported with a zip file, are registered as the __Zip import__ version. <!-- todo: add link to import -->
+    * Annotations predicted with a transcription model are named with the model's name. <!-- todo: add link to predict transcription -->
+
 ![Image: Illustration of the drop-down menu for selecting the version of the transcription](img/export/escriptorium_export_transcription_version.gif)
 
-### Selecting the annotation format to export
+### Selecting the output format
 
-You can select three exporting formats from the second drop-down menu:
-* Text for plain text   
+In the second drop-down menu, you can select between three output formats:
+
+* Text for plain text  
 * PAGE for [PAGE XML](http://www.primaresearch.org/publications/ICPR2010_Pletschacher_PAGE)
 * ALTO for [XML ALTO](https://www.loc.gov/standards/alto/) (Analyzed Layout and Text Object)
-    
-![Image: Illustration of the drop-down menu for selecting the exporting format](img/export/escriptorium_export_format.gif)
+
+![Image: Illustration of the drop-down menu for selecting the output format](img/export/escriptorium_export_format.gif)
 
 ### Including (or not) images linked to the annotations
 
-You can tick the checkbox if you want to include images that are linked to the annotations. As it is mentioned in the export pop-up box, and depending on the images' sizes, including image in the export can significantly increase the time to produce and download the export.
+You can include the images corresponding to the selected document-parts by ticking the "Include images" checkbox.
+
+As mentioned in the export pop-up box, and depending on the images' sizes, including image in the export can significantly increase the time to produce and download the export.
 
 ![Image: Ticking the checkbox for including images in the export](img/export/escriptorium_export_include_images.gif)
 
 ### Selecting the region types to export
 
-You can select the region types you want to export. <!-- todo: add link to the subsection about segment version -->
+You can include or exclude lines or whole regions and their associated lines with the last parameters. <!-- todo: add link to the subsection about segment version -->
 
-To do so, tick the checkboxex associated to the region types you want to export. 
+To do so, tick the checkboxes associated to the region types you want to export or uncheck the ones you want to ignore.  
 
 ![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif)
 
 !!! Note
     By default, there are __six region types__ available to export : Illustration, Commentary, Main, Title, (Undefined region type), (Orphan lines). (Undefined region type) are regions without a name. (Orphan lines) are lines not linked to any region. Make sure to always tick the checkbox for (Orphan lines) to avoid loosing any not-linked annotation.
-    
-You can export a region type even though no annotations are linked to it. It will be mentioned in the resulting exported file, but no annotations will be linked to it. 
+
+You can export a region type even though no annotations are linked to it. It will be mentioned in the resulting exported file, but no annotations will be linked to it.  
 
 !!! Note
     Region types' name will only appear when exporting in ALTO and PAGE. When exporting as plain text, only the annotations will be exported.
 
-## Downloading the export
+### Downloading the export
 
-Once all options are set, click on the blue "Export" button. A green pop-up box will appear in the upper-right section of the interface. Click on "Download" to download the part-documents you selected.
+Once all options are set, click on the "Export" button at the bottom of the pop-up. 
 
-When exporting ALTO and PAGE, the export is downloaded as a zip file containg each part-documents.
+Once the export is ready, a green message box will appear in the upper-right section of the interface, providing you with a download link. Click on "Download" to download the txt file or the zip file resulting from your export.
 
-When exporting plain text, the download will open a new tab with a new URL, containing the plain text. All annotations will be concatenated as one file text.
+When exporting ALTO and PAGE, the exported file is saved as a zip file containg an XML file per document-part, the corresponding images if included, as well as a METS XML file describing the ensemble.
+
+When exporting plain text, clicking on "Download" will redirect you to a new URL, displaying the plain text. All the transcriptions are concatenated as a single text file.
 
 ![Image: Illustration of the export](img/export/escriptorium_export_download.png)
 
 !!! Tip
-    To avoid confusions between exports, make sure to click on the cross icon in the download pop-up box before creating a new export.
+    If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file).  
+
+### Finding previous exports
+
+Each export is provided a unique permanent link. You can save it, for example to automatically re-download it later without having to set the whole export again but it is also possible to find the links to all your previous exports in the Profile page, under the "Files" tab.<!-- todo: add link to "review and edit your profile" which should logically be : [Profile page, under the "Files" tab](walkthrough_users.md#review-and-edit-your-profile)-->

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -65,15 +65,14 @@ You can include or exclude lines or whole regions and their associated lines wit
 
 To do so, tick the checkboxes associated to the region types you want to export or uncheck the ones you want to ignore.  
 
-![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif)
-
-!!! Note
-    By default, there are __six region types__ available to export : Illustration, Commentary, Main, Title, (Undefined region type), (Orphan lines). (Undefined region type) are regions without a name. (Orphan lines) are lines not linked to any region. Make sure to always tick the checkbox for (Orphan lines) to avoid losing isolated lines.
+The list of region types corresponds to the region types activated in the "Ontology" tab <!-- todo: add link to that once it's available -->. Two additional options allow you to include or ignore untyped-regions <!-- todo: add link to segmentation, which would hopefully explain that --> or orphan lines (lines that are not linked <!-- todo: add link to linking segments to regions -->to any region).
 
 You can export a region type even though it does not contain any transcription. In ALTO and PAGE files, the resulting regions will simply be an empty element.  
 
 !!! Note
-    Region types' name will only appear when exporting in ALTO and PAGE. In a plain text export, only the text contained in the transcription is kept.
+    Regions' type will only appear in ALTO and PAGE. In a plain text export, only the text contained in the transcription is kept.
+
+![Image: Ticking the region types' checkboxes chosen for the export](img/export/escriptorium_export_region_types.gif)  
 
 ### Download the export
 

--- a/docs/walkthrough_export.md
+++ b/docs/walkthrough_export.md
@@ -61,7 +61,7 @@ As mentioned in the export pop-up box, and depending on the images' size, includ
 
 ### Include or exclude certain region types or lines
 
-You can include or exclude lines or whole regions and their associated lines with the last parameters. <!-- todo: add link to the subsection about segment version -->
+You can include or exclude lines or whole regions and their associated lines with the last parameter. <!-- todo: add link to the subsection about segment version -->
 
 To do so, tick the checkboxes associated to the region types you want to export or uncheck the ones you want to ignore.  
 
@@ -76,9 +76,9 @@ You can export a region type even though it does not contain any transcription. 
 
 ### Download the export
 
-Once all options are set, click on the "Export" button at the bottom of the pop-up. 
+Once all options are set, click on the "Export" button at the bottom of the pop-up.  
 
-Once the export is ready, a green message box will appear in the upper-right section of the interface, providing you with a download link. Click on "Download" to download the txt file or the zip file resulting from your export.
+As soon as the export is ready, a green message box will appear in the upper-right section of the interface, providing you with a download link. Click on "Download" to download the txt file or the zip file resulting from your export.
 
 When exporting ALTO and PAGE, the exported file is saved as a zip file containg an XML file per document-part, the corresponding images if included, as well as a METS XML file describing the ensemble.
 
@@ -87,7 +87,7 @@ When exporting plain text, clicking on "Download" will redirect you to a new URL
 ![Image: Illustration of the export](img/export/escriptorium_export_download.png "Stating the export task and downloading the result.")
 
 !!! Tip
-    If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file).  
+    If you plan on doing several exports, we recommand to close the green message-box after each export (after downloading the file of course).  
 
 ### Find previous exports
 


### PR DESCRIPTION
I tried to break down my corrections so that they are more easy to follow:
- I rephrased a few things, namely to clarify the meaning of "annotation", and used transcription in stead whenever possible
- I shortened the titles, removing redundant informations
- I added a section on accessing the former exports and the permalink because we actually often forget about it and I had just written a description of it in the page on User-related features

Regarding the syntax: 
- since I was using VSCode, I used the linter to homogenize the spaces and empty lines (but no big deal)
- I didn't change your markdown syntax, but I think it would be useful to homogenize it inside a file and overall in the whole docs/  (we can make changes in the wiki)
- as I showed you earlier, I added the syntax to render the Keys (`++key-short-name++`)
- I added titles to images with the following syntax : `[image: alt text](path/to/img "Title of the image")`. It's pretty straight-forward and will display a "infobulle" with the title when hovering on the image.